### PR TITLE
Add a Len method to OrderedDict (and run through gofmt)

### DIFF
--- a/ordered_map.go
+++ b/ordered_map.go
@@ -1,22 +1,21 @@
 package ordered_map
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
 )
 
-
 type OrderedMap struct {
-	store map[interface{}]interface{}
+	store  map[interface{}]interface{}
 	mapper map[interface{}]*node
-	root *node
+	root   *node
 }
 
 func NewOrderedMap() *OrderedMap {
 	om := &OrderedMap{
-		store: make(map[interface{}]interface{}),
+		store:  make(map[interface{}]interface{}),
 		mapper: make(map[interface{}]*node),
-		root: newRootNode(),
+		root:   newRootNode(),
 	}
 	return om
 }
@@ -64,7 +63,7 @@ func (om *OrderedMap) Delete(key interface{}) {
 }
 
 func (om *OrderedMap) String() string {
-	builder := make ([]string, len(om.store))
+	builder := make([]string, len(om.store))
 
 	var index int = 0
 	for k := range om.Iter() {
@@ -77,7 +76,7 @@ func (om *OrderedMap) String() string {
 
 func (om *OrderedMap) Iter() <-chan *KVPair {
 	keys := make(chan *KVPair)
-	go func(){
+	go func() {
 		defer close(keys)
 		var curr *node
 		root := om.root
@@ -96,8 +95,8 @@ func (om *OrderedMap) Len() int {
 }
 
 type node struct {
-	Prev *node
-	Next *node
+	Prev  *node
+	Next  *node
 	Value interface{}
 }
 
@@ -108,9 +107,8 @@ func newRootNode() *node {
 	return root
 }
 
-
 func newNode(prev *node, next *node, key interface{}) *node {
-	return &node{Prev: prev, Next: next, Value:key}
+	return &node{Prev: prev, Next: next, Value: key}
 }
 
 func (n *node) add(value string) {
@@ -135,12 +133,12 @@ func (n *node) String() string {
 		// Else, print pointer value
 		buffer.WriteString(fmt.Sprintf("%p, ", &n))
 	}
-	return fmt.Sprintf("LinkList[%v]",buffer.String())
+	return fmt.Sprintf("LinkList[%v]", buffer.String())
 }
 
 func (n *node) iter() <-chan string {
 	keys := make(chan string)
-	go func(){
+	go func() {
 		defer close(keys)
 		var curr *node
 		root := n
@@ -153,14 +151,8 @@ func (n *node) iter() <-chan string {
 	return keys
 }
 
-
-
-
-
-
-
 type KVPair struct {
-	Key interface{}
+	Key   interface{}
 	Value interface{}
 }
 

--- a/ordered_map.go
+++ b/ordered_map.go
@@ -91,8 +91,9 @@ func (om *OrderedMap) Iter() <-chan *KVPair {
 	return keys
 }
 
-
-
+func (om *OrderedMap) Len() int {
+	return len(om.store)
+}
 
 type node struct {
 	Prev *node

--- a/ordered_map_test.go
+++ b/ordered_map_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-
 type MyStruct struct {
 	a float64
 	b bool
@@ -29,7 +28,6 @@ func testStringInt() []*KVPair {
 	data[4] = &KVPair{"test4", 4}
 	return data
 }
-
 
 func TestSetData(t *testing.T) {
 	expected := testStringInt()
@@ -104,10 +102,6 @@ func TestIterator(t *testing.T) {
 	}
 }
 
-
-
-
-
 func testString() []string {
 	var data []string = make([]string, 5)
 	data[0] = "test0"
@@ -117,7 +111,6 @@ func testString() []string {
 	data[4] = "test4"
 	return data
 }
-
 
 func TestAddData(t *testing.T) {
 	expected := testString()

--- a/ordered_map_test.go
+++ b/ordered_map_test.go
@@ -139,3 +139,20 @@ func TestAddData(t *testing.T) {
 		index++
 	}
 }
+
+func TestLenNonEmpty(t *testing.T) {
+	data := testStringInt()
+	om := NewOrderedMapWithArgs(data)
+
+	if om.Len() != len(data) {
+		t.Fatal("Unexpected length")
+	}
+}
+
+func TestLenEmpty(t *testing.T) {
+	om := NewOrderedMap()
+
+	if om.Len() != 0 {
+		t.Fatal("Unexpected length")
+	}
+}


### PR DESCRIPTION
I noticed that there was no equivalent to `len(m)` exposed for `OrderedDict` so i thought I'd add it.